### PR TITLE
Fix overflowing item states

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paperui/web/css/views.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paperui/web/css/views.css
@@ -32,6 +32,9 @@ section#main.control {
 
 .items .item h1.state {
 	margin: 5px 0px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .items .item h1.state:last-child {


### PR DESCRIPTION
This is a minor CSS fix to make lengthy item states fit the layout by
applying text-overflow: ellipsis

Fixes openhab/smarthome.paperui#5