### PR TITLE
remove Require-Bundle, it is not needed at all

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paperui/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.paperui/META-INF/MANIFEST.MF
@@ -12,5 +12,4 @@ Import-Package: org.osgi.service.component,
 Bundle-SymbolicName: org.eclipse.smarthome.ui.paperui;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*
-Require-Bundle: javax.servlet
 Bundle-ClassPath: patch/,.


### PR DESCRIPTION
Remove the "Require-Bundle" statement.
No "Import-Package" necessary as "javax.servlet" is not used at all.